### PR TITLE
Property "modelClass" isn't always required

### DIFF
--- a/src/Action.php
+++ b/src/Action.php
@@ -16,7 +16,6 @@ abstract class Action extends \yii\base\Action
     /**
      * @var string class name of the model which will be handled by this action.
      * The model class must implement [[ActiveRecordInterface]].
-     * This property must be set.
      */
     public $modelClass;
 
@@ -53,8 +52,9 @@ abstract class Action extends \yii\base\Action
      */
     public function init()
     {
-        if ($this->modelClass === null) {
-            throw new InvalidConfigException(get_class($this) . '::$modelClass must be set.');
+        if ($this->modelClass === null && $this->findModel === null) {
+            $className = get_class($this);
+            throw new InvalidConfigException("$className::\$modelClass or $className::\$findModel must be set.");
         }
     }
 

--- a/src/IndexAction.php
+++ b/src/IndexAction.php
@@ -2,6 +2,8 @@
 
 namespace strongsquirrel\actions;
 
+use yii\base\Action;
+use yii\base\InvalidConfigException;
 use yii\data\ActiveDataProvider;
 
 /**
@@ -17,6 +19,12 @@ class IndexAction extends Action
     public $view = 'index';
 
     /**
+     * @var string class name of the model which will be handled by this action.
+     * The model class must implement [[ActiveRecordInterface]].
+     */
+    public $modelClass;
+
+    /**
      * @var callable a PHP callable that will be called to prepare a data provider that
      * should return a collection of the models. If not set, [[prepareDataProvider()]] will be used instead.
      * The signature of the callable should be:
@@ -30,6 +38,31 @@ class IndexAction extends Action
      * The callable should return an instance of [[ActiveDataProvider]].
      */
     public $prepareDataProvider;
+
+    /**
+     * @var callable
+     * The signature of the callable should be as follows,
+     *
+     * ```php
+     * function ($action) {
+     *     // $action is the action object currently running
+     * }
+     * ```
+     */
+    public $checkAccess;
+
+    /**
+     * Initializes the object.
+     * This method is invoked at the end of the constructor after the object is initialized with the
+     * given configuration.
+     */
+    public function init()
+    {
+        if ($this->modelClass === null && $this->prepareDataProvider === null) {
+            $className = get_class($this);
+            throw new InvalidConfigException("$className::\$modelClass or $className::\$prepareDataProvider must be set.");
+        }
+    }
 
     /**
      * @return string


### PR DESCRIPTION
`Action::$modelClass` isn't required if `Action::$findModel` is set.
Similarly, `IndexAction::$prepareDataProvider`.
